### PR TITLE
Add support to illuminate/contracts v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0",
+        "illuminate/contracts": "^10.0 || ^11.0",
         "spatie/laravel-activitylog": "^4.7",
         "spatie/laravel-package-tools": "^1.14.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^10.0 || ^11.0",
-        "spatie/laravel-activitylog": "^4.7",
+        "spatie/laravel-activitylog": "^4.8",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {


### PR DESCRIPTION
Olá,

estou utilizando Laravel na versão 11 com FilamentPHP v3.

Ao instalar obtive o seguinte erro:

```bash
$ sail composer require rmsramos/activitylog
./composer.json has been updated
Running composer update rmsramos/activitylog
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires rmsramos/activitylog * -> satisfiable by rmsramos/activitylog[v0.1.0, v0.1.1, v0.1.2, v0.1.3].
    - rmsramos/activitylog[v0.1.0, ..., v0.1.3] require illuminate/contracts ^10.0 -> found illuminate/contracts[v10.0.0, ..., v10.48.4] but these were not loaded, likely because it conflicts with another require.

You can also try re-running composer require with an explicit version constraint, e.g. "composer require rmsramos/activitylog:*" to figure out if any version is installable, or "composer require rmsramos/activitylog:^2.1" if you know which you need.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

Tomei a liberdade de criar um fork do projeto e abrir esse PR para ter a compatibilidade em projetos Laravel V11.