### PR TITLE
added customization closures

### DIFF
--- a/src/Actions/ActivityLogTimelineAction.php
+++ b/src/Actions/ActivityLogTimelineAction.php
@@ -2,6 +2,7 @@
 
 namespace Rmsramos\Activitylog\Actions;
 
+use Closure;
 use Filament\Actions\StaticAction;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
@@ -24,6 +25,11 @@ class ActivityLogTimelineAction extends Action
     private ?array $timelineIconColors = null;
 
     private ?int $limit = 10;
+    protected Closure $modifyQueryUsing;
+    protected Closure|Builder $query;
+    protected ?Closure $activitiesUsing;
+    protected ?Closure $modifyTitleUsing;
+    protected ?Closure $shouldModifyTitleUsing;
 
     public static function getDefaultName(): ?string
     {
@@ -36,6 +42,30 @@ class ActivityLogTimelineAction extends Action
 
         $this->configureInfolist();
         $this->configureModal();
+        $this->activitiesUsing = null;
+        $this->modifyTitleUsing = null;
+        $this->shouldModifyTitleUsing = fn() => true;
+        $this->modifyQueryUsing = fn($builder) => $builder;
+        $this->modalHeading= __('activitylog::action.modal.heading');
+        $this->modalDescription = __('activitylog::action.modal.description');
+        $this->query = function(?Model $record) {
+            return Activity::query()
+                ->where(function (Builder $query) use ($record) {
+                    $query->where(function (Builder $q) use ($record) {
+                        $q->where('subject_type', $record->getMorphClass())
+                            ->where('subject_id', $record->getKey());
+                    })->when($this->getWithRelations(), function (Builder $query, array $relations) use ($record) {
+                        foreach ($relations as $relation) {
+                            $model = get_class($record->{$relation}()->getRelated());
+                            $query->orWhere(function (Builder $q) use ($record, $model, $relation) {
+                                $q->where('subject_type', (new $model())->getMorphClass())
+                                    ->whereIn('subject_id', $record->{$relation}()->pluck('id'));
+                            });
+                        }
+                    });
+                });
+
+        };
     }
 
     private function configureInfolist(): void
@@ -50,8 +80,6 @@ class ActivityLogTimelineAction extends Action
     private function configureModal(): void
     {
         $this->slideOver()
-            ->modalHeading(__('activitylog::action.modal.heading'))
-            ->modalDescription(__('activitylog::action.modal.description'))
             ->modalIcon('heroicon-o-eye')
             ->modalFooterActions(fn () => [])
             ->tooltip(__('activitylog::action.modal.tooltip'))
@@ -70,8 +98,13 @@ class ActivityLogTimelineAction extends Action
                         ->color(function ($state) {
                             return $this->getTimelineIconColors()[$state] ?? 'primary';
                         }),
-                    TimeLineTitleEntry::make('activityData'),
+                    TimeLineTitleEntry::make('activityData')
+                    ->configureTitleUsing($this->modifyTitleUsing)
+                    ->shouldConfigureTitleUsing($this->shouldModifyTitleUsing),
                     TimeLinePropertieEntry::make('activityData'),
+                    TextEntry::make('log_name')
+                        ->hiddenLabel()
+                        ->badge(),
                     TextEntry::make('updated_at')
                         ->hiddenLabel()
                         ->since()
@@ -128,29 +161,70 @@ class ActivityLogTimelineAction extends Action
         return $this->evaluate($this->limit);
     }
 
-    private function getActivities(?Model $record, ?array $relations = null): Collection
+    public function query(Closure|Builder|null $query): static
     {
-        return Activity::query()
-            ->where(function (Builder $query) use ($record, $relations) {
-                $query->where(function (Builder $q) use ($record) {
-                    $q->where('subject_type', $record->getMorphClass())
-                        ->where('subject_id', $record->getKey());
-                })->when($relations, function (Builder $query, array $relations) use ($record) {
-                    foreach ($relations as $relation) {
-                        $model = get_class($record->{$relation}()->getRelated());
-                        $query->orWhere(function (Builder $q) use ($record, $model, $relation) {
-                            $q->where('subject_type', (new $model())->getMorphClass())
-                                ->whereIn('subject_id', $record->{$relation}()->pluck('id'));
-                        });
-                    }
-                });
-            })
-            ->latest()
-            ->limit($this->getLimit())
-            ->get();
+        $this->query = $query;
+        return $this;
     }
 
-    private function getActivityLogRecord(?Model $record, ?array $relations = null): Collection
+    public function getQuery(): ?Builder
+    {
+        return $this->evaluate($this->query);
+    }
+
+    public function modifyQueryUsing(Closure $closure): static
+    {
+        $this->modifyQueryUsing = $closure;
+        return $this;
+    }
+
+    public function getModifyQueryUsing(Builder $builder): Builder
+    {
+        $this->evaluate($this->modifyQueryUsing, ['builder' => $builder]);
+        return  $builder;
+    }
+
+    public function modifyTitleUsing(Closure $closure): static
+    {
+        $this->modifyTitleUsing = $closure;
+        return $this;
+    }
+
+    public function shouldModifyTitleUsing(Closure $closure): static
+    {
+        $this->shouldModifyTitleUsing = $closure;
+        return $this;
+    }
+
+
+
+    public function activitiesUsing(Closure $closure): static
+    {
+        $this->activitiesUsing = $closure;
+        return $this;
+    }
+
+    public function getActivitiesUsing(): ?Collection
+    {
+        return $this->evaluate($this->activitiesUsing);
+    }
+
+
+    protected function getActivities(?Model $record, ?array $relations = null): Collection
+    {
+        if($activities = $this->getActivitiesUsing()) {
+            return $activities;
+        } else {
+            $builder = $this->getQuery()
+                ->latest()
+                ->limit($this->getLimit());
+            $this->getModifyQueryUsing($builder);
+            return $builder
+                ->get();
+        }
+    }
+
+    protected function getActivityLogRecord(?Model $record, ?array $relations = null): Collection
     {
         $activities = $this->getActivities($record, $relations);
 
@@ -161,7 +235,9 @@ class ActivityLogTimelineAction extends Action
         });
     }
 
-    private function formatActivityData($activity): array
+
+
+    protected function formatActivityData($activity): array
     {
         return [
             'log_name'    => $activity->log_name,

--- a/src/Infolists/Components/TimeLineTitleEntry.php
+++ b/src/Infolists/Components/TimeLineTitleEntry.php
@@ -3,6 +3,7 @@
 namespace Rmsramos\Activitylog\Infolists\Components;
 
 use Carbon\Carbon;
+use Closure;
 use Filament\Forms\Components\Concerns\CanAllowHtml;
 use Filament\Infolists\Components\Entry;
 use Filament\Support\Concerns\HasExtraAttributes;
@@ -16,6 +17,9 @@ class TimeLineTitleEntry extends Entry
     use HasExtraAttributes;
     use HasModifyState;
 
+    protected ?Closure $configureTitleUsing = null;
+    protected ?Closure $shouldConfigureTitleUsing = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -24,6 +28,22 @@ class TimeLineTitleEntry extends Entry
     }
 
     protected string $view = 'activitylog::filament.infolists.components.time-line-title-entry';
+
+
+
+    public function configureTitleUsing(?Closure $configureTitleUsing): TimeLineTitleEntry
+    {
+        $this->configureTitleUsing = $configureTitleUsing;
+        return $this;
+    }
+
+    public function shouldConfigureTitleUsing(?Closure $condition): TimeLineTitleEntry
+    {
+        $this->shouldConfigureTitleUsing = $condition;
+        return $this;
+    }
+
+
 
     private function configureTitleEntry()
     {
@@ -34,20 +54,24 @@ class TimeLineTitleEntry extends Entry
 
     private function modifiedTitle($state): string|HtmlString
     {
-        if ($state['description'] == $state['event']) {
-            $className  = Str::lower(Str::snake(class_basename($state['subject']), ' '));
-            $causerName = $this->getCauserName($state['causer']);
-            $update_at  = Carbon::parse($state['update'])->translatedFormat(config('filament-activitylog.datetime_format'));
+        if(null !== $this->configureTitleUsing && null !== $this->shouldConfigureTitleUsing && $this->evaluate($this->shouldConfigureTitleUsing)) {
+            return $this->evaluate($this->configureTitleUsing);
+        } else {
+            if ($state['description'] == $state['event']) {
+                $className = Str::lower(Str::snake(class_basename($state['subject']), ' '));
+                $causerName = $this->getCauserName($state['causer']);
+                $update_at = Carbon::parse($state['update'])->translatedFormat(config('filament-activitylog.datetime_format'));
 
-            return new HtmlString(
-                sprintf(
-                    'The <strong>%s</strong> was <strong>%s</strong> by <strong>%s</strong>. <br><small> Updated at: <strong>%s</strong></small>',
-                    $className,
-                    $state['event'],
-                    $causerName,
-                    $update_at
-                )
-            );
+                return new HtmlString(
+                    sprintf(
+                        'The <strong>%s</strong> was <strong>%s</strong> by <strong>%s</strong>. <br><small> Updated at: <strong>%s</strong></small>',
+                        $className,
+                        $state['event'],
+                        $causerName,
+                        $update_at
+                    )
+                );
+            }
         }
 
         return '';

--- a/src/Infolists/Concerns/HasModifyState.php
+++ b/src/Infolists/Concerns/HasModifyState.php
@@ -16,7 +16,7 @@ trait HasModifyState
         return $this;
     }
 
-    public function getModifiedState(): ?HtmlString
+    public function getModifiedState(): null|string|HtmlString
     {
         return $this->evaluate($this->state);
     }


### PR DESCRIPTION
- Added the ability to modify the eloquent query via closure  
- Added the ability to provide the list of activities via closure
- Added the ability to set the text/value for `TimeLineTitleEntry` via closure

all of the closures are backed by the `evaluate()` function so you're able to inject the regular filament variables like `$record`, `$component` etc

```php
ActivityLogTimelineAction::make('Activities')
    ->modifyQueryUsing(function (Builder $query) { 
    //some logic modify the query
    // ex return $query->where('log_name', '=', 'custom');
    })
```

```php
ActivityLogTimelineAction::make('Activities')
    ->activitiesUsing(function (Model $record) { 
    //some logic to fetch the activities as a collection
    // ex Activity::all() or $record->activities;
    })
```

```php
ActivityLogTimelineAction::make('Activities')
 ->shouldModifyTitleUsing(function (Activity $record) {
        //by default returns true, allows user to selectively skip the custom modifyTitleUsing function
        return $record->description !== $record->event;
    })
  ->modifyTitleUsing(function (Activity $record) {
      return $record->description;
  })
```


- fixes #25. [HasModifiedState getModifiedState](https://github.com/rmsramos/activitylog/blob/b8b3426c911d7d0a823a8d08261340d517251cba/src/Infolists/Concerns/HasModifyState.php#L19)  is typed to return `HtmlString` but  [TimeLineTitleEntry](https://github.com/rmsramos/activitylog/blob/b8b3426c911d7d0a823a8d08261340d517251cba/src/Infolists/Components/TimeLineTitleEntry.php#L53) can return a regular string if the description does not match the event. 