### PR TITLE
Remove unnecessary / typo single quote

### DIFF
--- a/src/Infolists/Components/TimeLinePropertiesEntry.php
+++ b/src/Infolists/Components/TimeLinePropertiesEntry.php
@@ -64,7 +64,7 @@ class TimeLinePropertiesEntry extends Entry
             if (isset($oldValues[$key]) && $oldValues[$key] != $newValue) {
                 $changes[] = "- {$key} from <strong>" . htmlspecialchars($oldValue) . '</strong> to <strong>' . htmlspecialchars($newValue) . '</strong>';
             } else {
-                $changes[] = "- {$key} <strong>'" . htmlspecialchars($newValue) . '</strong>';
+                $changes[] = "- {$key} <strong>" . htmlspecialchars($newValue) . '</strong>';
             }
         }
 


### PR DESCRIPTION
This removes the unnecessary (typo?) single quote in the action timeline.

Currently, there's an extra / unused **'** 

<img width="741" alt="image" src="https://github.com/user-attachments/assets/79a0b338-c386-4001-9315-fdd3bdce8b8e">

Frankly, I'd argue that this entire `}else{` is not necessary. It seems weird to build up an array of changes and include things that aren't actually changed. It also makes it challenging to spot the items that were changed. To me it seems like a lot of extra noise. 