### PR TITLE
Added feature to enable/disable the navigation item

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ return [
     'resources' => [
         'label'                     => 'Activity Log',
         'plural_label'              => 'Activity Logs',
+        'navigation_item'           => true,
         'navigation_group'          => null,
         'navigation_icon'           => 'heroicon-o-shield-check',
         'navigation_sort'           => null,
@@ -166,6 +167,23 @@ public function panel(Panel $panel): Panel
             ActivitylogPlugin::make()
                 ->label('Log')
                 ->pluralLabel('Logs'),
+        ]);
+}
+```
+
+## Displaying the resource in the navigation
+
+You can enable or disable the `Resource navigation item` by updating the `->navigationItem()` value.
+
+```php
+use Rmsramos\Activitylog\ActivitylogPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            ActivitylogPlugin::make()
+                ->navigationItem(false), // by default is true
         ]);
 }
 ```
@@ -288,6 +306,7 @@ public function panel(Panel $panel): Panel
                 ->resource(\Path\For\Your\CustomResource::class)
                 ->label('Log')
                 ->pluralLabel('Logs')
+                ->navigationItem(true)
                 ->navigationGroup('Activity Log')
                 ->navigationIcon('heroicon-o-shield-check')
                 ->navigationCountBadge(true)

--- a/config/filament-activitylog.php
+++ b/config/filament-activitylog.php
@@ -4,6 +4,7 @@ return [
     'resources' => [
         'label'                  => 'Activity Log',
         'plural_label'           => 'Activity Logs',
+        'navigation_item'        => true,
         'navigation_group'       => null,
         'navigation_icon'        => 'heroicon-o-shield-check',
         'navigation_sort'        => null,

--- a/src/ActivitylogPlugin.php
+++ b/src/ActivitylogPlugin.php
@@ -15,6 +15,8 @@ class ActivitylogPlugin implements Plugin
 
     protected string|Closure|null $label = null;
 
+    protected Closure|bool $navigationItem = true;
+
     protected string|Closure|null $navigationGroup = null;
 
     protected ?string $navigationIcon = null;
@@ -70,6 +72,11 @@ class ActivitylogPlugin implements Plugin
         return $this->evaluate($this->pluralLabel) ?? config('filament-activitylog.resources.plural_label');
     }
 
+    public function getNavigationItem(): bool
+    {
+        return $this->evaluate($this->navigationItem) ?? config('filament-activitylog.resources.navigation_item');
+    }
+
     public function getNavigationGroup(): ?string
     {
         return $this->evaluate($this->navigationGroup) ?? config('filament-activitylog.resources.navigation_group');
@@ -107,6 +114,13 @@ class ActivitylogPlugin implements Plugin
     public function pluralLabel(string|Closure $label): static
     {
         $this->pluralLabel = $label;
+
+        return $this;
+    }
+
+    public function navigationItem(Closure | bool $value = true): static
+    {
+        $this->navigationItem = $value;
 
         return $this;
     }

--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -2,6 +2,7 @@
 
 namespace Rmsramos\Activitylog\Resources;
 
+use Filament\Facades\Filament;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\Placeholder;
@@ -292,6 +293,13 @@ class ActivitylogResource extends Resource
             'index' => ListActivitylog::route('/'),
             'view'  => ViewActivitylog::route('/{record}'),
         ];
+    }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        $plugin = Filament::getCurrentPanel()?->getPlugin('rmsramos/activitylog');
+
+        return $plugin->getNavigationItem();
     }
 
     public static function canAccess(): bool


### PR DESCRIPTION
- Added `navigation_item` configuration option to config/filament-activitylog.php.
- Updated ActivitylogPlugin to include `navigationItem` property and methods.
- Updated ActivitylogResource to check `navigationItem` configuration.
- Updated README.md with instructions for configuring the navigation item visibility.