### PR TITLE
Lazy Loading activitylog.css to Prevent Unnecessary Conflicts and Asset Overload

### DIFF
--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -35,7 +35,7 @@ class ActivitylogServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         $assets = [
-            Css::make('activitylog-styles', __DIR__ . '/../resources/dist/activitylog.css'),
+            Css::make('activitylog-styles', __DIR__ . '/../resources/dist/activitylog.css')->loadedOnRequest(),
         ];
 
         FilamentAsset::register($assets, 'rmsramos/activitylog');


### PR DESCRIPTION
This pull request introduces the loadedOnRequest() method to prevent the activitylog.css file from being loaded automatically. This change follows the official Filament documentation for [lazy-loading assets](https://filamentphp.com/docs/3.x/support/assets#lazy-loading-css).

Problem:
The current implementation injects activitylog.css globally, wherever the @filamentStyles directive is used. This includes the admin panel, custom pages, and any Livewire or normal Blade pages. As a result, it leads to:
- Unnecessary conflicts with other stylesheets.
- Increased asset size and load times, even when activitylog.css is not needed.

Solution:
By applying the loadedOnRequest() method, we ensure that activitylog.css is only loaded when explicitly requested, reducing unwanted style conflicts and improving asset performance.