### PR TITLE
feat: add Portuguese language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ ActivityLog Plugin is translated for :
 -   🇫🇷 French
 -   🇮🇷 Persian
 -   🇦🇪 Arabic
+-   🇵🇹 Portuguese
 
 ## Installation
 

--- a/resources/lang/pt_PT/action.php
+++ b/resources/lang/pt_PT/action.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'modal' => [
+        'heading'     => 'Registro de Logs do utilizador',
+        'description' => 'Acompanhe todas as atividades do utilizador.',
+        'tooltip'     => 'Atividades do utilizador',
+    ],
+];

--- a/resources/lang/pt_PT/forms.php
+++ b/resources/lang/pt_PT/forms.php
@@ -1,0 +1,33 @@
+<?php
+
+return [
+    'fields' => [
+        'log_name' => [
+            'label' => 'Tipo',
+        ],
+        'event' => [
+            'label' => 'Evento',
+        ],
+        'subject_type' => [
+            'label' => 'Assunto',
+        ],
+        'causer' => [
+            'label' => 'Utilizador',
+        ],
+        'description' => [
+            'label' => 'Descrição',
+        ],
+        'properties' => [
+            'label' => 'Propriedades',
+        ],
+        'created_at' => [
+            'label' => 'Criando em',
+        ],
+        'old' => [
+            'label' => 'Antigo',
+        ],
+        'attributes' => [
+            'label' => 'Novo',
+        ],
+    ],
+];

--- a/resources/lang/pt_PT/tables.php
+++ b/resources/lang/pt_PT/tables.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    'columns' => [
+        'log_name' => [
+            'label' => 'Tipo',
+        ],
+        'event' => [
+            'label' => 'Evento',
+        ],
+        'subject_type' => [
+            'label' => 'Assunto',
+        ],
+        'causer' => [
+            'label' => 'Utilizador',
+        ],
+        'properties' => [
+            'label' => 'Propriedades',
+        ],
+        'created_at' => [
+            'label' => 'Criado em',
+        ],
+    ],
+    'filters' => [
+        'created_at' => [
+            'label'         => 'Criado em',
+            'created_from'  => 'Criado a partir de ',
+            'created_until' => 'Criado até ',
+        ],
+        'event' => [
+            'label' => 'Eventos',
+        ],
+    ],
+];


### PR DESCRIPTION
Extended the language support by adding Portuguese translations in the new pt_PT directory. Updated README to reflect the inclusion of Portuguese as a supported language.
