### PR TITLE
Make Table Columns Searchable

### DIFF
--- a/resources/views/filament/tables/columns/activity-logs-properties.blade.php
+++ b/resources/views/filament/tables/columns/activity-logs-properties.blade.php
@@ -1,5 +1,5 @@
 <div class="my-2 text-sm tracking-tight">
-    @foreach($getState() as $key => $value)
+    @foreach($getState() ?? [] as $key => $value)
         <span class="inline-block p-1 mr-1 font-medium text-gray-700 whitespace-normal rounded-md dark:text-gray-200 bg-gray-500/10">
             {{ $key }}
         </span>

--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -162,30 +162,31 @@ class ActivitylogResource extends Resource
     {
         return $table
             ->columns([
-                static::getLogNameColumnCompoment(),
-                static::getEventColumnCompoment(),
-                static::getSubjectTypeColumnCompoment(),
-                static::getCauserNameColumnCompoment(),
-                static::getPropertiesColumnCompoment(),
-                static::getCreatedAtColumnCompoment(),
+                static::getLogNameColumnComponent(),
+                static::getEventColumnComponent(),
+                static::getSubjectTypeColumnComponent(),
+                static::getCauserNameColumnComponent(),
+                static::getPropertiesColumnComponent(),
+                static::getCreatedAtColumnComponent(),
             ])
             ->defaultSort(config('filament-activitylog.resources.default_sort_column', 'created_at'), config('filament-activitylog.resources.default_sort_direction', 'asc'))
             ->filters([
                 static::getDateFilterComponent(),
-                static::getEventFilterCompoment(),
+                static::getEventFilterComponent(),
             ]);
     }
 
-    public static function getLogNameColumnCompoment(): Column
+    public static function getLogNameColumnComponent(): Column
     {
         return TextColumn::make('log_name')
             ->label(__('activitylog::tables.columns.log_name.label'))
-            ->badge()
             ->formatStateUsing(fn ($state) => ucwords($state))
-            ->sortable();
+            ->searchable()
+            ->sortable()
+            ->badge();
     }
 
-    public static function getEventColumnCompoment(): Column
+    public static function getEventColumnComponent(): Column
     {
         return TextColumn::make('event')
             ->label(__('activitylog::tables.columns.event.label'))
@@ -198,10 +199,11 @@ class ActivitylogResource extends Resource
                 'deleted' => 'danger',
                 default   => 'primary',
             })
+            ->searchable()
             ->sortable();
     }
 
-    public static function getSubjectTypeColumnCompoment(): Column
+    public static function getSubjectTypeColumnComponent(): Column
     {
         return TextColumn::make('subject_type')
             ->label(__('activitylog::tables.columns.subject_type.label'))
@@ -213,10 +215,11 @@ class ActivitylogResource extends Resource
 
                 return Str::of($state)->afterLast('\\')->headline() . ' # ' . $record->subject_id;
             })
+            ->searchable()
             ->hidden(fn (Livewire $livewire) => $livewire instanceof ActivitylogRelationManager);
     }
 
-    public static function getCauserNameColumnCompoment(): Column
+    public static function getCauserNameColumnComponent(): Column
     {
         return TextColumn::make('causer.name')
             ->label(__('activitylog::tables.columns.causer.label'))
@@ -231,19 +234,21 @@ class ActivitylogResource extends Resource
             ->searchable();
     }
 
-    public static function getPropertiesColumnCompoment(): Column
+    public static function getPropertiesColumnComponent(): Column
     {
         return ViewColumn::make('properties')
+            ->searchable()
             ->label(__('activitylog::tables.columns.properties.label'))
             ->view('activitylog::filament.tables.columns.activity-logs-properties')
             ->toggleable(isToggledHiddenByDefault: true);
     }
 
-    public static function getCreatedAtColumnCompoment(): Column
+    public static function getCreatedAtColumnComponent(): Column
     {
         return TextColumn::make('created_at')
             ->label(__('activitylog::tables.columns.created_at.label'))
             ->dateTime(config('filament-activitylog.datetime_format', 'd/m/Y H:i:s'))
+            ->searchable()
             ->sortable();
     }
 
@@ -283,7 +288,7 @@ class ActivitylogResource extends Resource
             });
     }
 
-    public static function getEventFilterCompoment(): SelectFilter
+    public static function getEventFilterComponent(): SelectFilter
     {
         return SelectFilter::make('event')
             ->label(__('activitylog::tables.filters.event.label'))


### PR DESCRIPTION
Adds the `searchable()` method to the table's columns and provides an empty array fallback for the `properties` column