### PR TITLE
Fixed string conversion into date if not needed

### DIFF
--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -273,12 +273,41 @@ trait ActionContent
             return $value;
         }
 
-        try {
+        if (self::isValidDate($value)) {
             return Carbon::parse($value)
                 ->format(config('filament-activitylog.datetime_format', 'd/m/Y H:i:s'));
-        } catch (InvalidFormatException $e) {
-            return $value;
         }
+
+        return $value;
+    }
+
+    private static function isValidDate(string $dateString, string $dateFormat = 'Y-m-d', string $dateTimeFormat = 'Y-m-d H:i:s'): bool|string
+    {
+        try {
+
+            $dateTime = CarbonImmutable::createFromFormat($dateFormat, $dateString);
+
+            if ($dateTime && $dateTime->format($dateFormat) === $dateString) {
+                return true;
+            }
+
+        } catch (InvalidFormatException $e) {
+
+        }
+
+        try {
+
+            $dateTime = CarbonImmutable::createFromFormat($dateTimeFormat, $dateString);
+
+            if ($dateTime && $dateTime->format($dateTimeFormat) === $dateString) {
+                return true;
+            }
+
+        } catch (InvalidFormatException $e) {
+
+        }
+
+        return false;
     }
 
 }


### PR DESCRIPTION
A better way to check if string is a valid date and needs to be converted.

Values like "N", "Y" or "s" with Carbon::parse are converted into date although if it's not need