### PR TITLE
Fix date formatting issue for integers in properties

### DIFF
--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -269,7 +269,10 @@ trait ActionContent
             foreach ($value as &$item) {
                 $item = self::formatDateValues($item);
             }
+            return $value;
+        }
 
+        if (is_numeric($value) && !preg_match('/^\d{10,}$/', $value)) {
             return $value;
         }
 


### PR DESCRIPTION
### Details of the Issue

When logging changes, the `formatDateValues` method attempts to parse integer value as a date. This leads updated integers  being displayed in a date format when they should remain as integers. exemple :

```
{
    "old": {
        "network": 5732
    },
    "attributes": {
        "network": 5731
    }
}
```

However, the log displayed:
- **Formatted Log**: `- network from 04/11/5732 03:47:55 to 04/11/5731 03:47:55`

![image](https://github.com/user-attachments/assets/5b37a69e-5cd0-47ed-ac72-e2f363158e94)

### Changes Made

- Modified the formatDateValues method to prevent numeric values from being treated as dates, ensuring that large integers remain unchanged and are only formatted if they are actual date strings (like timestamps).

Thank you for considering this pull request! 🙏🏼 
