### PR TITLE
Fix error on activities without event

### DIFF
--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -287,7 +287,7 @@ class ActivitylogResource extends Resource
     {
         return SelectFilter::make('event')
             ->label(__('activitylog::tables.filters.event.label'))
-            ->options(static::getModel()::distinct()->pluck('event', 'event'));
+            ->options(static::getModel()::distinct()->pluck('event', 'event')->filter());
     }
 
     public static function getPages(): array


### PR DESCRIPTION
Hello,

Activities event may be null. This PR solves an error with null events triggering an error on SelectFilter (which doesn't allow null-index options).