### PR TITLE
Fix: Prevent numeric values from being incorrectly parsed as dates.

### DIFF
--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -273,7 +273,7 @@ trait ActionContent
             return $value;
         }
 
-        f (is_numeric($value)) {
+        if (is_numeric($value)) {
             return $value;
         }
 

--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -273,6 +273,10 @@ trait ActionContent
             return $value;
         }
 
+        f (is_numeric($value)) {
+            return $value;
+        }
+
         try {
             return Carbon::parse($value)
                 ->format(config('filament-activitylog.datetime_format', 'd/m/Y H:i:s'));


### PR DESCRIPTION
Fix: Prevent numeric values from being incorrectly parsed as dates in `formatDateValues`

Added a check to return numeric values without parsing them as dates. Previously, values like `206.55` were parsed into incorrect dates such as "01/01/1970 00:03:26" without raising an exception. This change ensures numeric values are returned as-is, preventing unintended date parsing and preserving data integrity.