### PR TITLE
Eager load 'subject' and 'causer' on timeline activity

### DIFF
--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -56,6 +56,7 @@ trait ActionContent
         $this->modalDescription       = __('activitylog::action.modal.description');
         $this->query                  = function (?Model $record) {
             return Activity::query()
+                ->load(['subject', 'causer'])
                 ->where(function (Builder $query) use ($record) {
                     $query->where(function (Builder $q) use ($record) {
                         $q->where('subject_type', $record->getMorphClass())

--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -56,7 +56,7 @@ trait ActionContent
         $this->modalDescription       = __('activitylog::action.modal.description');
         $this->query                  = function (?Model $record) {
             return Activity::query()
-                ->load(['subject', 'causer'])
+                ->with(['subject', 'causer'])
                 ->where(function (Builder $query) use ($record) {
                     $query->where(function (Builder $q) use ($record) {
                         $q->where('subject_type', $record->getMorphClass())

--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -188,9 +188,7 @@ trait ActionContent
 
     public function getModifyQueryUsing(Builder $builder): Builder
     {
-        $this->evaluate($this->modifyQueryUsing, ['builder' => $builder]);
-
-        return $builder;
+        return $this->evaluate($this->modifyQueryUsing, ['builder' => $builder]);
     }
 
     public function modifyTitleUsing(Closure $closure): static
@@ -227,9 +225,7 @@ trait ActionContent
             $builder = $this->getQuery()
                 ->latest()
                 ->limit($this->getLimit());
-            $this->getModifyQueryUsing($builder);
-
-            return $builder
+            return $this->getModifyQueryUsing($builder)
                 ->get();
         }
     }


### PR DESCRIPTION
Prevents lazy loading errors when using [eloquent in strict mode](https://laravel.com/docs/11.x/eloquent#configuring-eloquent-strictness). May also improve performance of queries.

Also fixes issue with this action's `modifyQueryUsing` not being correctly applied.