### PR TITLE
Fix attempt to read property `name` on null

### DIFF
--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -222,11 +222,11 @@ class ActivitylogResource extends Resource
             ->label(__('activitylog::tables.columns.causer.label'))
             ->getStateUsing(function (Model $record) {
 
-                if ($record->causer_id == null) {
+                if ($record->causer == null) {
                     return new HtmlString('&mdash;');
                 }
 
-                return $record->causer->name;
+                return $record->causer?->name;
             })
             ->searchable();
     }


### PR DESCRIPTION
I'm not sure where .. but I got this error when trying to see the logs:

```
{"message":"Attempt to read property \"name\" on null (View: /var/www/html/vendor/filament/tables/resources/views/index.blade.php) (View: /var/www/html/vendor/filament/tables/resources/views/in
dex.blade.php)","context":{"userId":1,"exception":{"class":"Illuminate\\View\\ViewException","message":"Attempt to read property \"name\" on null (View: /var/www/html/vendor/filament/tables/resources/views/index.blade.php) (View: /var/www/html/
vendor/filament/tables/resources/views/index.blade.php)","code":0,"file":"/var/www/html/vendor/rmsramos/activitylog/src/Resources/ActivitylogResource.php:229","previous":{"class":"Illuminate\\View\\ViewException","message":"Attempt to read prop
erty \"name\" on null (View: /var/www/html/vendor/filament/tables/resources/views/index.blade.php)","code":0,"file":"/var/www/html/vendor/rmsramos/activitylog/src/Resources/ActivitylogResource.php:229","previous":{"class":"ErrorException","message":"Attempt to read property \"name\" on null","code":0,"file":"/var/www/html/vendor/rmsramos/ac
```

Simply adding a null safety check after the causer fixes this issue.