### PR TITLE
Fix: Handle null causer in getCauserNameColumnCompoment

### DIFF
--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -221,11 +221,12 @@ class ActivitylogResource extends Resource
         return TextColumn::make('causer.name')
             ->label(__('activitylog::tables.columns.causer.label'))
             ->getStateUsing(function (Model $record) {
-
-                if ($record->causer_id == null) {
+                // Check if causer is null or causer_id is null
+                if ($record->causer_id == null || $record->causer == null) {
                     return new HtmlString('&mdash;');
                 }
 
+                // Return the causer's name if causer exists
                 return $record->causer->name;
             })
             ->searchable();


### PR DESCRIPTION
### Description
This PR fixes an issue where accessing the `causer` relationship throws an error when the `causer` is deleted or `null`. The `getCauserNameColumnCompoment` method now checks if `causer` or `causer_id` is `null` and returns `&mdash;` as a fallback.

### Changes
- Added null checks for `causer` and `causer_id` in the `getCauserNameColumnCompoment` method.
- Ensured consistent behavior when the causer is deleted or null.