### PR TITLE
feat: added custom activity title name in model

### DIFF
--- a/src/Infolists/Components/TimeLineTitleEntry.php
+++ b/src/Infolists/Components/TimeLineTitleEntry.php
@@ -57,7 +57,9 @@ class TimeLineTitleEntry extends Entry
             return $this->evaluate($this->configureTitleUsing);
         } else {
             if ($state['description'] == $state['event']) {
-                $className  = Str::lower(Str::snake(class_basename($state['subject']), ' '));
+                $className = property_exists($state['subject'], 'activityTitleName') && !empty($state['subject']::$activityTitleName)
+                    ? $state['subject']::$activityTitleName
+                    : Str::lower(Str::snake(class_basename($state['subject']), ' '));
                 $causerName = $this->getCauserName($state['causer']);
                 $update_at  = Carbon::parse($state['update'])->translatedFormat(config('filament-activitylog.datetime_format'));
 


### PR DESCRIPTION
Now you can change the title of model activity
In my case, I have my "property" model, which I want to be translated into spanish, so i just add a variable to my model and modify the title in the activity.
![imagen](https://github.com/user-attachments/assets/902b0129-139e-4a0f-82da-04593bee0f3b)

After add variable in my model:
![imagen](https://github.com/user-attachments/assets/5b930114-f629-4d9a-8d1f-2e1df2b75361)


How to use? Just add the variable "activityTitleName" in your model, like:
`public static ?string $activityTitleName = 'propiedad';`

![imagen](https://github.com/user-attachments/assets/432e2e29-cb5b-40c8-8988-d628f2ffec53)

