### PR TITLE
Activity Model Configuration PR

### DIFF
--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -30,6 +30,7 @@ use Rmsramos\Activitylog\ActivitylogPlugin;
 use Rmsramos\Activitylog\RelationManagers\ActivitylogRelationManager;
 use Rmsramos\Activitylog\Resources\ActivitylogResource\Pages\ListActivitylog;
 use Rmsramos\Activitylog\Resources\ActivitylogResource\Pages\ViewActivitylog;
+use Spatie\Activitylog\Models\Activity;
 
 class ActivitylogResource extends Resource
 {
@@ -39,7 +40,7 @@ class ActivitylogResource extends Resource
 
     public static function getModel(): string
     {
-        return config('activitylog.activity_model');
+        return config('activitylog.activity_model', Activity::class);
     }
 
     public static function getModelLabel(): string

--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -30,7 +30,6 @@ use Rmsramos\Activitylog\ActivitylogPlugin;
 use Rmsramos\Activitylog\RelationManagers\ActivitylogRelationManager;
 use Rmsramos\Activitylog\Resources\ActivitylogResource\Pages\ListActivitylog;
 use Rmsramos\Activitylog\Resources\ActivitylogResource\Pages\ViewActivitylog;
-use Spatie\Activitylog\Models\Activity;
 
 class ActivitylogResource extends Resource
 {
@@ -40,7 +39,7 @@ class ActivitylogResource extends Resource
 
     public static function getModel(): string
     {
-        return Activity::class;
+        return config('activitylog.activity_model');
     }
 
     public static function getModelLabel(): string


### PR DESCRIPTION
Changed the hardcoded Activity model reference to use the configurable option from the package configuration file. This allows for easier customization of the Activity model without modifying the core package code.

This change enables users to specify their own Activity model implementation in the config file, supporting use cases where the default model needs to be extended or replaced.

Using a custom Resource still won't use a custom model, even if you overload the `getModel()` method, thus this patch to instead dynamically read the active Activitylog model from the configuration.