### PR TITLE
Add formatting of nested arrays as JSON

### DIFF
--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -312,4 +312,19 @@ trait ActionContent
 
         return false;
     }
+
+    private static function normalizeProperties(array|string|null $value): array|string|null
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        foreach ($value as &$item) {
+            if (is_array($item)) {
+                $item = json_encode($item, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+            }
+        }
+
+        return $value;
+    }
 }

--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -145,13 +145,13 @@ class ActivitylogResource extends Resource
 
                         if ($old = $record->properties->get('old')) {
                             $schema[] = KeyValue::make('old')
-                                ->formatStateUsing(fn () => self::formatDateValues($old))
+                                ->formatStateUsing(fn () => self::normalizeProperties(self::formatDateValues($old)))
                                 ->label(__('activitylog::forms.fields.old.label'));
                         }
 
                         if ($attributes = $record->properties->get('attributes')) {
                             $schema[] = KeyValue::make('attributes')
-                                ->formatStateUsing(fn () => self::formatDateValues($attributes))
+                                ->formatStateUsing(fn () => self::normalizeProperties(self::formatDateValues($attributes)))
                                 ->label(__('activitylog::forms.fields.attributes.label'));
                         }
 


### PR DESCRIPTION
Currently, JSON/array fields are displayed as `[object Object]` in the UI. This update improves the output by rendering these fields as formatted JSON strings instead, making the data readable and clear

Current:
![image](https://github.com/user-attachments/assets/13a4d6ff-fd01-4566-a05d-d7b8b1e30797)
New:
![image](https://github.com/user-attachments/assets/e8deabb7-17f2-4585-a453-4a82327d46ad)