### PR TITLE
Make classes more extendable for DX

### DIFF
--- a/src/Actions/Concerns/ActionContent.php
+++ b/src/Actions/Concerns/ActionContent.php
@@ -19,23 +19,23 @@ use Spatie\Activitylog\Models\Activity;
 
 trait ActionContent
 {
-    private ?array $withRelations = null;
+    protected ?array $withRelations = null;
 
-    private ?array $timelineIcons = [
+    protected ?array $timelineIcons = [
         'created'  => 'heroicon-m-plus',
         'updated'  => 'heroicon-m-pencil-square',
         'deleted'  => 'heroicon-m-trash',
         'restored' => 'heroicon-m-arrow-uturn-left',
     ];
 
-    private ?array $timelineIconColors = [
+    protected ?array $timelineIconColors = [
         'created'  => 'success',
         'updated'  => 'warning',
         'deleted'  => 'danger',
         'restored' => 'info',
     ];
 
-    private ?int $limit = 10;
+    protected ?int $limit = 10;
 
     protected Closure $modifyQueryUsing;
 
@@ -106,7 +106,7 @@ trait ActionContent
                 });
         };
     }
-    private function configureInfolist(): void
+    protected function configureInfolist(): void
     {
         $this->infolist(function (?Model $record, Infolist $infolist) {
             $activities = $this->getActivityLogRecord($record, $this->getWithRelations());
@@ -126,7 +126,7 @@ trait ActionContent
         });
     }
 
-    private function configureModal(): void
+    protected function configureModal(): void
     {
         $this->slideOver()
             ->modalIcon('heroicon-o-eye')
@@ -135,7 +135,7 @@ trait ActionContent
             ->icon('heroicon-o-bell-alert');
     }
 
-    private function getSchema(): array
+    protected function getSchema(): array
     {
         return [
             TimeLineRepeatableEntry::make('activities')
@@ -320,7 +320,7 @@ trait ActionContent
         ];
     }
 
-    private static function formatDateValues(array|string|null $value): array|string|null
+    protected static function formatDateValues(array|string|null $value): array|string|null
     {
         if (is_null($value)) {
             return $value;

--- a/src/Infolists/Components/TimeLineIconEntry.php
+++ b/src/Infolists/Components/TimeLineIconEntry.php
@@ -15,7 +15,7 @@ class TimeLineIconEntry extends IconEntry
 
     protected string $view = 'activitylog::filament.infolists.components.time-line-icon-entry';
 
-    private function configureIconEntry()
+    protected function configureIconEntry()
     {
         $this
             ->hiddenLabel()

--- a/src/Infolists/Components/TimeLinePropertiesEntry.php
+++ b/src/Infolists/Components/TimeLinePropertiesEntry.php
@@ -19,14 +19,14 @@ class TimeLinePropertiesEntry extends Entry
         $this->configurePropertieEntry();
     }
 
-    private function configurePropertieEntry(): void
+    protected function configurePropertieEntry(): void
     {
         $this
             ->hiddenLabel()
             ->modifyState(fn ($state) => $this->modifiedProperties($state));
     }
 
-    private function modifiedProperties($state): ?HtmlString
+    protected function modifiedProperties($state): ?HtmlString
     {
         $properties = $state['properties'];
 
@@ -44,7 +44,7 @@ class TimeLinePropertiesEntry extends Entry
         return null;
     }
 
-    private function getPropertyChanges(array $properties): array
+    protected function getPropertyChanges(array $properties): array
     {
         $changes = [];
 
@@ -59,7 +59,7 @@ class TimeLinePropertiesEntry extends Entry
         return $changes;
     }
 
-    private function compareOldAndNewValues(array $oldValues, array $newValues): array
+    protected function compareOldAndNewValues(array $oldValues, array $newValues): array
     {
         $changes = [];
 
@@ -86,7 +86,7 @@ class TimeLinePropertiesEntry extends Entry
         return $changes;
     }
 
-    private function getNewValues(array $newValues): array
+    protected function getNewValues(array $newValues): array
     {
         return array_map(
             fn ($key, $value) => sprintf(
@@ -99,7 +99,7 @@ class TimeLinePropertiesEntry extends Entry
         );
     }
 
-    private function formatNewValue($value): string
+    protected function formatNewValue($value): string
     {
         return is_array($value) ? json_encode($value) : $value ?? '—';
     }

--- a/src/Infolists/Components/TimeLineRepeatableEntry.php
+++ b/src/Infolists/Components/TimeLineRepeatableEntry.php
@@ -13,7 +13,7 @@ class TimeLineRepeatableEntry extends RepeatableEntry
         $this->configureRepeatableEntry();
     }
 
-    private function configureRepeatableEntry(): void
+    protected function configureRepeatableEntry(): void
     {
         $this
             ->extraAttributes(['style' => 'margin-left:1.25rem;'])

--- a/src/Infolists/Components/TimeLineTitleEntry.php
+++ b/src/Infolists/Components/TimeLineTitleEntry.php
@@ -44,14 +44,14 @@ class TimeLineTitleEntry extends Entry
         return $this;
     }
 
-    private function configureTitleEntry()
+    protected function configureTitleEntry()
     {
         $this
             ->hiddenLabel()
             ->modifyState(fn ($state) => $this->modifiedTitle($state));
     }
 
-    private function modifiedTitle($state): string|HtmlString|Closure
+    protected function modifiedTitle($state): string|HtmlString|Closure
     {
         if ($this->configureTitleUsing !== null && $this->shouldConfigureTitleUsing !== null && $this->evaluate($this->shouldConfigureTitleUsing)) {
             return $this->evaluate($this->configureTitleUsing, ['state' => $state]);

--- a/src/Infolists/Concerns/HasModifyState.php
+++ b/src/Infolists/Concerns/HasModifyState.php
@@ -21,7 +21,7 @@ trait HasModifyState
         return $this->evaluate($this->state);
     }
 
-    private function getCauserName($causer): string
+    protected function getCauserName($causer): string
     {
         return $causer->name ?? $causer->first_name ?? $causer->last_name ?? $causer->username ?? trans('activitylog::infolists.components.unknown');
     }

--- a/src/Resources/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource.php
@@ -86,7 +86,7 @@ class ActivitylogResource extends Resource
             number_format(static::getModel()::count()) : null;
     }
 
-    private static function getResourceUrl(Activity $record): string
+    protected static function getResourceUrl(Activity $record): string
     {
         $panelID = Filament::getCurrentPanel()->getId();
 
@@ -253,7 +253,7 @@ class ActivitylogResource extends Resource
             ])->columns(1);
     }
 
-    private static function flattenArrayForKeyValue(array $data): array
+    protected static function flattenArrayForKeyValue(array $data): array
     {
         $flattened = [];
 
@@ -491,7 +491,7 @@ class ActivitylogResource extends Resource
         return ActivitylogPlugin::get()->isAuthorized();
     }
 
-    private static function canViewResource(Activity $record): bool
+    protected static function canViewResource(Activity $record): bool
     {
         if ($record->subject_type && $record->subject_id) {
             try {


### PR DESCRIPTION
This PR converts all `private` properties and methods to `protected`.

See #102

Currently most of the useful methods are not customisable by extending the base classes of this project, making things like the following impossible:

```php
<?php

namespace App\Filament\Infolists\Components;

use Rmsramos\Activitylog\Infolists\Components\TimeLinePropertiesEntry as BaseTimeLinePropertiesEntry;

class TimeLinePropertiesEntry extends BaseTimeLinePropertiesEntry
{
    protected function getPropertyChanges(array $properties): array
    {
        $changes = parent::getPropertyChanges($properties);

        // My custom changes logic here
        
        return $changes;
    }
}
```

I think `private` methods aren't really useful unless you have some critical core code that you do not trust other developers to extend or override.

The same goes for properties unless they are holding some particularly sensitive data you don't want extending classes to access.

I'd be interested to hear your thoughts on this PR and if there was any reason for the `private` stuff that I've missed.