### PR TITLE
Add support for translating activity log key names

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,23 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+## Translate Activity log key Names
+
+To translate the names of the keys in the activity log, add a `translateLogKey` callback within the `ActivitylogPlugin` chain
+
+```php
+use Rmsramos\Activitylog\ActivitylogPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            ActivitylogPlugin::make()
+                ->translateLogKey(fn($label) => __("yourCustomLangFile.".$label)),
+        ]);
+}
+```
+
 ## Customize Date Parsing
 
 To customize how dates are parsed, depending on user preferences or settings:

--- a/src/ActivitylogPlugin.php
+++ b/src/ActivitylogPlugin.php
@@ -40,6 +40,8 @@ class ActivitylogPlugin implements Plugin
 
     protected ?Closure $translateSubject = null;
 
+    protected ?Closure $translateLogKey = null;
+
     protected ?string $navigationIcon = null;
 
     protected ?int $navigationSort = null;
@@ -150,6 +152,17 @@ class ActivitylogPlugin implements Plugin
         }
 
         $callable = $this->translateSubject;
+
+        return $callable($label);
+    }
+
+    public function getTranslateLogKey($label): ?string
+    {
+        if (is_null($this->translateLogKey)) {
+            return $label;
+        }
+
+        $callable = $this->translateLogKey;
 
         return $callable($label);
     }
@@ -275,6 +288,13 @@ class ActivitylogPlugin implements Plugin
     public function translateSubject(string|Closure|null $callable = null): static
     {
         $this->translateSubject = $callable;
+
+        return $this;
+    }
+
+    public function translateLogKey(string|Closure|null $callable = null): static
+    {
+        $this->translateLogKey = $callable;
 
         return $this;
     }

--- a/src/Infolists/Components/TimeLinePropertiesEntry.php
+++ b/src/Infolists/Components/TimeLinePropertiesEntry.php
@@ -4,6 +4,7 @@ namespace Rmsramos\Activitylog\Infolists\Components;
 
 use Filament\Infolists\Components\Entry;
 use Illuminate\Support\HtmlString;
+use Rmsramos\Activitylog\ActivitylogPlugin;
 use Rmsramos\Activitylog\Infolists\Concerns\HasModifyState;
 
 class TimeLinePropertiesEntry extends Entry
@@ -70,14 +71,14 @@ class TimeLinePropertiesEntry extends Entry
             if (isset($oldValues[$key]) && $oldValues[$key] != $newValue) {
                 $changes[] = trans('activitylog::infolists.components.from_oldvalue_to_newvalue',
                     [
-                        'key'       => $key,
+                        'key'       => ActivitylogPlugin::get()->getTranslateLogKey($key),
                         'old_value' => htmlspecialchars($oldValue),
                         'new_value' => htmlspecialchars($newValue),
                     ]);
             } else {
                 $changes[] = trans('activitylog::infolists.components.to_newvalue',
                     [
-                        'key'       => $key,
+                        'key'       => ActivitylogPlugin::get()->getTranslateLogKey($key),
                         'new_value' => htmlspecialchars($newValue),
                     ]);
             }
@@ -91,7 +92,7 @@ class TimeLinePropertiesEntry extends Entry
         return array_map(
             fn ($key, $value) => sprintf(
                 __('activitylog::timeline.properties.getNewValues'),
-                $key,
+                ActivitylogPlugin::get()->getTranslateLogKey($key),
                 htmlspecialchars($this->formatNewValue($value))
             ),
             array_keys($newValues),


### PR DESCRIPTION
Introduces a `translateLogKey` callback to ActivitylogPlugin, allowing customization of key name translations in activity logs.