### PR TITLE
Add Filament v4 support (v3.0.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
+        "filament/filament": "^4.0 || ^5.0",
         "illuminate/contracts": "^11.0||^12.0",
         "spatie/laravel-activitylog": "^4.8",
         "spatie/laravel-package-tools": "^1.16"

--- a/src/RelationManagers/ActivitylogRelationManager.php
+++ b/src/RelationManagers/ActivitylogRelationManager.php
@@ -2,13 +2,15 @@
 
 namespace Rmsramos\Activitylog\RelationManagers;
 
+use Filament\Actions\ViewAction as ActionsViewAction;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Rmsramos\Activitylog\ActivitylogPlugin;
-use Rmsramos\Activitylog\Resources\ActivitylogResource;
+use Rmsramos\Activitylog\Resources\ActivitylogResource\ActivitylogResource;
 
 class ActivitylogRelationManager extends RelationManager
 {
@@ -24,9 +26,9 @@ class ActivitylogRelationManager extends RelationManager
             ->headline();
     }
 
-    public function form(Form $form): Form
+    public function form(Schema $Schema): Schema
     {
-        return ActivitylogResource::form($form);
+        return ActivitylogResource::form($Schema);
     }
 
     public function table(Table $table): Table
@@ -34,8 +36,8 @@ class ActivitylogRelationManager extends RelationManager
         return ActivitylogResource::table(
             $table
                 ->heading(ActivitylogPlugin::get()->getPluralLabel())
-                ->actions([
-                    ViewAction::make(),
+                ->headerActions([
+                    ActionsViewAction::make(),
                 ])
         );
     }

--- a/src/Resources/ActivitylogResource/ActivitylogResource.php
+++ b/src/Resources/ActivitylogResource/ActivitylogResource.php
@@ -2,36 +2,36 @@
 
 namespace Rmsramos\Activitylog\Resources\ActivitylogResource;
 
-use ActivitylogForm;
+
 use Exception;
-use Filament\Facades\Filament;
-use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Placeholder;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
 use Filament\Schemas\Schema;
+use Filament\Facades\Filament;
+use Filament\Resources\Resource;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\HtmlString;
 use Filament\Tables\Columns\Column;
+use Filament\Tables\Filters\Filter;
+use Livewire\Component as Livewire;
+use Illuminate\Support\Facades\Gate;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\ViewColumn;
-use Filament\Tables\Filters\Filter;
-use Filament\Tables\Filters\SelectFilter;
-use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
-use Livewire\Component as Livewire;
-use Rmsramos\Activitylog\Actions\Concerns\ActionContent;
+use Spatie\Activitylog\Models\Activity;
+use Filament\Notifications\Notification;
+use Filament\Forms\Components\DatePicker;
+use Filament\Tables\Filters\SelectFilter;
+use Illuminate\Database\Eloquent\Builder;
 use Rmsramos\Activitylog\ActivitylogPlugin;
 use Rmsramos\Activitylog\Helpers\ActivityLogHelper;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Rmsramos\Activitylog\Actions\Concerns\ActionContent;
+use Rmsramos\Activitylog\Traits\HasCustomActivityResource;
 use Rmsramos\Activitylog\RelationManagers\ActivitylogRelationManager;
 use Rmsramos\Activitylog\Resources\ActivitylogResource\Pages\ListActivitylog;
 use Rmsramos\Activitylog\Resources\ActivitylogResource\Pages\ViewActivitylog;
-use Rmsramos\Activitylog\Traits\HasCustomActivityResource;
-use Spatie\Activitylog\Models\Activity;
+use Rmsramos\Activitylog\Resources\ActivitylogResource\Schemas\ActivitylogForm;
 
 class ActivitylogResource extends Resource
 {
@@ -299,7 +299,7 @@ class ActivitylogResource extends Resource
 
                 return $indicators;
             })
-            ->form([
+            ->schema([
                 self::getDatePickerCompoment('created_from'),
                 self::getDatePickerCompoment('created_until'),
             ])

--- a/src/Resources/ActivitylogResource/Pages/ListActivitylog.php
+++ b/src/Resources/ActivitylogResource/Pages/ListActivitylog.php
@@ -3,7 +3,7 @@
 namespace Rmsramos\Activitylog\Resources\ActivitylogResource\Pages;
 
 use Filament\Resources\Pages\ListRecords;
-use Rmsramos\Activitylog\Resources\ActivitylogResource;
+use Rmsramos\Activitylog\Resources\ActivitylogResource\ActivitylogResource;
 
 class ListActivitylog extends ListRecords
 {

--- a/src/Resources/ActivitylogResource/Pages/ViewActivitylog.php
+++ b/src/Resources/ActivitylogResource/Pages/ViewActivitylog.php
@@ -3,7 +3,7 @@
 namespace Rmsramos\Activitylog\Resources\ActivitylogResource\Pages;
 
 use Filament\Resources\Pages\ViewRecord;
-use Rmsramos\Activitylog\Resources\ActivitylogResource;
+use Rmsramos\Activitylog\Resources\ActivitylogResource\ActivitylogResource;
 
 class ViewActivitylog extends ViewRecord
 {

--- a/src/Resources/ActivitylogResource/Schemas/ActivitylogForm.php
+++ b/src/Resources/ActivitylogResource/Schemas/ActivitylogForm.php
@@ -1,12 +1,15 @@
 <?php
 
-use Filament\Forms\Components\Textarea;
-use Filament\Forms\Components\TextInput;
-use Filament\Infolists\Components\TextEntry;
-use Filament\Schemas\Components\Section;
+namespace Rmsramos\Activitylog\Resources\ActivitylogResource\Schemas;
+
+use Illuminate\Support\Str;
 use Filament\Schemas\Schema;
+use Filament\Forms\Components\Textarea;
 use Illuminate\Database\Eloquent\Model;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Section;
 use Rmsramos\Activitylog\ActivitylogPlugin;
+use Filament\Infolists\Components\TextEntry;
 
 class ActivitylogForm
 {
@@ -24,7 +27,7 @@ class ActivitylogForm
                     TextInput::make('subject_type')
                         ->afterStateHydrated(function ($component, ?Model $record, $state) {
                             /** @var Activity $record */
-                            return $state ? $component->state(Str::of($state)->afterLast('\\')->headline().' # '.$record->subject_id) : $component->state('-');
+                            return $state ? $component->state(Str::of($state)->afterLast('\\')->headline() . ' # ' . $record->subject_id) : $component->state('-');
                         })
                         ->label(__('activitylog::forms.fields.subject_type.label')),
 
@@ -36,32 +39,40 @@ class ActivitylogForm
 
                 Section::make([
                     TextEntry::make('log_name')
-                        ->content(function (?Model $record): string {
-                            /** @var Activity $record */
-                            return $record?->log_name ? ucwords($record->log_name) : '-';
+                        ->state(function (?Model $record): string {
+                            /** @var Activity|null $record */
+                            return $record?->log_name
+                                ? ucwords($record->log_name)
+                                : '-';
                         })
                         ->label(__('activitylog::forms.fields.log_name.label')),
 
+
                     TextEntry::make('event')
-                        ->content(function (?Model $record): string {
-                            /** @var Activity $record */
-                            return $record?->event ? ucwords(__('activitylog::action.event.'.$record->event)) : '-';
+                        ->state(function (?Model $record): string {
+                            /** @var Activity|null $record */
+                            return $record?->event
+                                ? ucwords(__('activitylog::action.event.' . $record->event))
+                                : '-';
                         })
                         ->label(__('activitylog::forms.fields.event.label')),
 
+
                     TextEntry::make('created_at')
                         ->label(__('activitylog::forms.fields.created_at.label'))
-                        ->content(function (?Model $record): string {
-                            /** @var Activity $record */
-                            if (! $record?->created_at) {
-                                return '-';
+                        ->state(function (?Model $record): ?string {
+                            /** @var Activity|null $record */
+                            if (!$record?->created_at) {
+                                return null;
                             }
 
                             $parser = ActivitylogPlugin::get()->getDateParser();
 
                             return $parser($record->created_at)
                                 ->format(ActivitylogPlugin::get()->getDatetimeFormat());
-                        }),
+                        })
+                        ->placeholder('-'),
+
                 ]),
             ]);
     }


### PR DESCRIPTION
### 🚀 Filament v4 Support (v3.0.0)

This PR adds full compatibility with Filament v4.

#### Changes
- Updated plugin registration to Filament v4
- Updated composer requirements
- Refactored deprecated Filament v3 APIs
- Tested locally with Laravel 12 + Filament v4

#### Testing
- Local Laravel app
- Activity log UI verified
- No runtime errors

#### Notes
- Backward compatibility with Filament v3 is NOT included